### PR TITLE
ENHANCEMENT - Dockerized Server and DB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ COPY src ./src
 RUN mvn package -DskipTests
 
 FROM openjdk:11-jre-slim AS deploy
-COPY --from=build /app/target/*.jar /app/app.jar
+COPY --from=build /app/target/*.war /app/app.war
 EXPOSE 8080
-CMD ["java", "-jar", "/app/app.jar"]
+CMD ["java", "-jar", "/app/app.war"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM maven:3.8.4-openjdk-11-slim AS build
+WORKDIR /app
+COPY pom.xml .
+RUN mvn dependency:go-offline -B
+COPY src ./src
+RUN mvn package -DskipTests
+
+FROM tomcat:9.0.54-jdk11-openjdk-slim
+# Changing the name also changges the context path, so the application will be available at /api
+COPY --from=build /app/target/*.war /usr/local/tomcat/webapps/api.war
+EXPOSE 8080
+CMD ["catalina.sh", "run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ RUN mvn dependency:go-offline -B
 COPY src ./src
 RUN mvn package -DskipTests
 
-FROM tomcat:9.0.54-jdk11-openjdk-slim AS deploy
-# Changing the name also changges the context path, so the application will be available at /api
-COPY --from=build /app/target/*.war /usr/local/tomcat/webapps/api.war
+FROM openjdk:11-jre-slim AS deploy
+COPY --from=build /app/target/*.jar /app/app.jar
 EXPOSE 8080
-CMD ["catalina.sh", "run"]
+CMD ["java", "-jar", "/app/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN mvn dependency:go-offline -B
 COPY src ./src
 RUN mvn package -DskipTests
 
-FROM tomcat:9.0.54-jdk11-openjdk-slim
+FROM tomcat:9.0.54-jdk11-openjdk-slim AS deploy
 # Changing the name also changges the context path, so the application will be available at /api
 COPY --from=build /app/target/*.war /usr/local/tomcat/webapps/api.war
 EXPOSE 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       MYSQL_USER: ${DATABASE_USERNAME}
       MYSQL_PASSWORD: ${DATABASE_PASSWORD}
     volumes:
-      - db_data:/var/lib/mysql
+      - ${DB_DATA_PATH}:/var/lib/mysql
 
   backend:
     build:
@@ -22,7 +22,7 @@ services:
     depends_on:
       - db
     environment:
-      AVATAR_STORAGE_FOLDER_PATH: ./avatars
+      AVATAR_STORAGE_FOLDER_PATH: /app/avatars
       DATABASE_HOST: db
       DATABASE_NAME: ${DATABASE_NAME}
       DATABASE_PASSWORD: ${DATABASE_PASSWORD}
@@ -30,6 +30,5 @@ services:
       DATABASE_USERNAME: ${DATABASE_USERNAME}
       JWT_SECRET: ${JWT_SECRET}
     volumes:
-      - .:/app
-volumes:
-  db_data:
+      - ${AVATAR_STORAGE_FOLDER_PATH}:/app/avatars
+      - ${STATIC_FILES_PATH}:/app/static_assets

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.1'
+
+services:
+
+  db:
+    image: mysql:8.3.0
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${DATABASE_NAME}
+      MYSQL_USER: ${DATABASE_USERNAME}
+      MYSQL_PASSWORD: ${DATABASE_PASSWORD}
+    volumes:
+      - db_data:/var/lib/mysql
+
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+    environment:
+      AVATAR_STORAGE_FOLDER_PATH: ./avatars
+      DATABASE_HOST: db
+      DATABASE_NAME: ${DATABASE_NAME}
+      DATABASE_PASSWORD: ${DATABASE_PASSWORD}
+      DATABASE_PORT: 3306
+      DATABASE_USERNAME: ${DATABASE_USERNAME}
+      JWT_SECRET: ${JWT_SECRET}
+    volumes:
+      - .:/app
+volumes:
+  db_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ version: '3.1'
 
 services:
 
-  db:
-    image: mysql:8.3.0
+  mysql:
+    image: mysql:8
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
@@ -11,7 +11,7 @@ services:
       MYSQL_USER: ${DATABASE_USERNAME}
       MYSQL_PASSWORD: ${DATABASE_PASSWORD}
     volumes:
-      - /c/Users/usr/OpenToonix/DB:/var/lib/mysql
+      - mysql:/var/lib/mysql
 
   backend:
     build:
@@ -20,16 +20,18 @@ services:
     ports:
       - "8080:8080"
     depends_on:
-      - db
+      - mysql
     environment:
       AVATAR_STORAGE_FOLDER_PATH: /app/avatars
-      DATABASE_HOST: db
+      DATABASE_HOST: mysql
       DATABASE_NAME: ${DATABASE_NAME}
       DATABASE_PASSWORD: ${DATABASE_PASSWORD}
       DATABASE_PORT: 3306
       DATABASE_USERNAME: ${DATABASE_USERNAME}
       JWT_SECRET: ${JWT_SECRET}
     volumes:
-      - /c/Users/usr/OpenToonix/Avatar:/app/avatar
+      - avatars:/app/avatar
 
-
+volumes:
+    mysql:
+    avatars:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,4 +31,3 @@ services:
       JWT_SECRET: ${JWT_SECRET}
     volumes:
       - ${AVATAR_STORAGE_FOLDER_PATH}:/app/avatars
-      - ${STATIC_FILES_PATH}:/app/static_assets

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       MYSQL_USER: ${DATABASE_USERNAME}
       MYSQL_PASSWORD: ${DATABASE_PASSWORD}
     volumes:
-      - ${DB_DATA_PATH}:/var/lib/mysql
+      - /c/Users/usr/OpenToonix/DB:/var/lib/mysql
 
   backend:
     build:
@@ -30,4 +30,6 @@ services:
       DATABASE_USERNAME: ${DATABASE_USERNAME}
       JWT_SECRET: ${JWT_SECRET}
     volumes:
-      - ${AVATAR_STORAGE_FOLDER_PATH}:/app/avatars
+      - /c/Users/usr/OpenToonix/Avatar:/app/avatar
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 	<name>OpenToonix HTTP Server</name>
 	<description>HTTP web server emulator for Toonix World</description>
 	<url>https://opentoonix.juansecu.com</url>
-	<packaging>jar</packaging>
+	<packaging>war</packaging>
 
 	<properties>
 		<java.version>11</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 	<name>OpenToonix HTTP Server</name>
 	<description>HTTP web server emulator for Toonix World</description>
 	<url>https://opentoonix.juansecu.com</url>
-	<packaging>war</packaging>
+	<packaging>jar</packaging>
 
 	<properties>
 		<java.version>11</java.version>


### PR DESCRIPTION
This pull request addresses issue #3.

### Changes Made
- Added a Dockerfile that defines a build stage to package into the .war file
- Included a second deploy stage in the Dockerfile to serve the application via a Tomcat server on port 8080 with the path `/api`
- Added the docker-compose.yml file to include a MySQL database and environment variables for the HTTP server
- Added a new environment variable MYSQL_ROOT_PASSWORD for the MySQL database
### Instructions
To start the services, execute the following command:
```bash
docker compose -f docker-compose.yml -p opentoonix-http-server up -d
```

Please review and merge as appropriate. Thank you!
